### PR TITLE
correction rofi-help_appfinder

### DIFF
--- a/components/rofi-help_appfinder
+++ b/components/rofi-help_appfinder
@@ -12,7 +12,7 @@ if [ x"$@" = x"Settings" ];
 then
 killall rofi
 sleep 0.25
-bash /bin/appfinder-settings
+bash /usr/bin/appfinder-settings
 fi
 
 echo -e "Appfinder\0icon\x1fhelp-browser"


### PR DESCRIPTION
fix path for appfinder-settings script to /usr/bin